### PR TITLE
 PA-1959  (PA-2232) fix: removed redundant logfile creation

### DIFF
--- a/scripts/extract_cdata.ps1
+++ b/scripts/extract_cdata.ps1
@@ -15,17 +15,6 @@ Add-content $LogFile -value $LogMessage
 <# Create a log file in the relative directory of the script if it is not already existent. #>
 $scriptDir = $PSScriptRoot
 $Logfile = $scriptDir + "\LogFile.log"
-try
-{
-    if (!(Test-Path "$Logfile"))
-    {
-       New-Item -name $Logfile -type "file"
-    }
-}
-catch
-{
-    echo "Log file not found. Creating it."
-}
 
 $params = @{"JobName"=$job;
  "ExecutionType"="Run";

--- a/scripts/transform.ps1
+++ b/scripts/transform.ps1
@@ -62,17 +62,6 @@ Param ([string]$cmdType)
 $scriptDir = $PSScriptRoot
 $Logfile = $scriptDir + "\LogFile.log"
 $responseFile=$scriptDir + "\response.txt"
-try
-{
-    if (!(Test-Path "$Logfile"))
-    {
-       New-Item -name $Logfile -type "file"
-    }
-}
-catch
-{
-    echo "Log file not found. Creating it."
-}
 
 Execute-dbt("run")
 Execute-dbt("test")


### PR DESCRIPTION
- the log file creation is done automatically when writing something to the output and is not error prone