### PR TITLE
feat: replace generate id macro DNA-12353 (DNA-19241)

### DIFF
--- a/.pipelines/azure-pipelines-spell-check.yml
+++ b/.pipelines/azure-pipelines-spell-check.yml
@@ -6,7 +6,7 @@ resources:
       endpoint: UiPath
       type: github
       name: UiPath/ProcessMining-framework-resources
-      ref: refs/tags/spell_check.0.1.0
+      ref: refs/tags/spell_check.0.2.0
 
 # By leaving the trigger undefined, the pipeline starts on each push to any branch.
 # Therefore it is not necessary to also start it via a PR.

--- a/transformations/models/3_events/Events_base.sql
+++ b/transformations/models/3_events/Events_base.sql
@@ -1,8 +1,3 @@
--- An event ID is generated to join event properties to the event log.
-{{ config(
-    post_hook="{{ pm_utils.generate_id('Event_ID_internal') }}"
-) }}
-
 with Invoice_create_events as (
     select * from {{ ref('Invoice_create_events') }}
 ),
@@ -88,4 +83,7 @@ Events_base as (
     from Purchase_order_create_events
 )
 
-select * from Events_base
+select
+    *,
+    {{ pm_utils.id() }} as "Event_ID_internal"
+from Events_base

--- a/transformations/models/4_event_logs/Purchase_order_event_log.sql
+++ b/transformations/models/4_event_logs/Purchase_order_event_log.sql
@@ -1,7 +1,3 @@
-{{ config(
-    post_hook="{{ pm_utils.generate_id('Event_ID') }}"
-) }}
-
 with Entity_relations as (
     select * from {{ ref('Entity_relations') }}
 ),
@@ -54,6 +50,7 @@ Purchase_order_event_log as (
         Purchase_order_event_log_preprocessing."Purchase_order_ID",
         Events_base."Activity",
         Events_base."Event_end",
+        {{ pm_utils.id() }} as "Event_ID",
         -- Optional event fields
         Events_base."Event_detail",
         Events_base."Team",

--- a/transformations/models/5_business_logic/Tags_base.sql
+++ b/transformations/models/5_business_logic/Tags_base.sql
@@ -1,7 +1,3 @@
-{{ config(
-    post_hook="{{ pm_utils.generate_id('Tag_ID') }}"
-) }}
-
 with Purchase_orders as (
     select * from {{ ref('Purchase_orders') }}
 ),
@@ -73,7 +69,8 @@ Tags_preprocessing as (
 Tags_base as (
     select
         Tags_preprocessing."Purchase_order_ID" as "Case_ID",
-        Tags_preprocessing."Tag"
+        Tags_preprocessing."Tag",
+        {{ pm_utils.id() }} as "Tag_ID"
     from Tags_preprocessing
 )
 

--- a/transformations/packages.yml
+++ b/transformations/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/UiPath/ProcessMining-pm-utils.git" # git URL
-    revision: v0.14.2
+    revision: v0.15.0


### PR DESCRIPTION
- update `pm-utils`.
- replace `generate_id` macro with the `id` macro.
- update the version used for the `spell_check`.